### PR TITLE
Update requirements.txt - fix dotenv version typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ streamlit==1.30.0
 wordcloud==1.9.3
 plotly==5.22.0
 matplotlib==3.8.4
-python-dotenv==1.01
+python-dotenv==1.0.1


### PR DESCRIPTION
Version 1.01 doesn't exist in pypi - the latest version s 1.0.1 https://pypi.org/project/python-dotenv/