### PR TITLE
Remove docker socket mount from kafka container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,8 +64,6 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_CREATE_TOPICS: "raw_airline_tweet:1:1"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - tutorial_network
 


### PR DESCRIPTION
Hi Adam!
Thanks for the workshop yesterday!
I tried to follow along, but as I am using Podman instead of Docker, i got the following error when trying to start the containers:
```
❯docker compose up kafka

[+] Running 2/2
 ✔ Network pydata-prefect-workshop_tutorial_network  Created                                                                                             0.0s
 ✔ Container pydata-prefect-workshop-zookeeper-1     Created                                                                                             0.2s
 ⠋ Container pydata-prefect-workshop-kafka-1         Creating                                                                                            0.0s
Error response from daemon: container create: statfs /var/run/docker.sock: permission denied
Error: executing /home/mag/.docker/cli-plugins/docker-compose up kafka: exit status 1
```

By removing the mount everything seemed to work.